### PR TITLE
update eso version from 0.17.0 to 0.18.2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "helm_release" "external_secrets" {
   name             = "external-secrets"
   repository       = "https://charts.external-secrets.io"
   chart            = "external-secrets"
-  version          = "0.17.0"
+  version          = "0.18.2"
   namespace     = kubernetes_namespace.external_secrets_operator.id
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {


### PR DESCRIPTION
As part of the component upgrade: external-secret-operator we need to update from 0.17.0 to 0.18.2 as the next version update for this

the version 0.18.0 has been tested in a test cluster